### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,10 +40,9 @@ Suggests: testthat,
   bayesmeta,
   utils,
   kableExtra,
-  roxygen2,
   bookdown,
   MendelianRandomization
-URL: https://github.com/okezie94/mrbayes
+URL: https://github.com/okezie94/mrbayes, https://okezie94.github.io/mrbayes/
 BugReports: https://github.com/okezie94/mrbayes/issues
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Also remove roxygen2 from Suggests as its dependency is declared with the `RoxygenNote` field.