### PR TITLE
Update R CMD check GitHub Actions workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, MendelianRandomization=?ignore-before-r=4.4.0
           needs: check
           upgrade: 'TRUE'
 


### PR DESCRIPTION
Ignore MendelianRandomization before R 4.4.0, this is because it's hard dependency rjson now requires R >= 4.4.0.